### PR TITLE
Set `__version__`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+ci:
+  autoupdate_schedule: "monthly"
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0
@@ -7,7 +9,7 @@ repos:
   - id: trailing-whitespace
   - id: debug-statements
 - repo: https://github.com/psf/black
-  rev: 22.6.0
+  rev: 22.10.0
   hooks:
   - id: black
     files: ^openff
@@ -17,7 +19,7 @@ repos:
   - id: isort
     files: ^openff
 - repo: https://github.com/PyCQA/flake8
-  rev: 4.0.1
+  rev: 5.0.4
   hooks:
   - id: flake8
     files: ^openff
@@ -28,7 +30,7 @@ repos:
         'flake8-no-pep420',
     ]
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.37.1
+  rev: v3.2.2
   hooks:
   - id: pyupgrade
     files: ^openff

--- a/openff/models/__init__.py
+++ b/openff/models/__init__.py
@@ -1,0 +1,7 @@
+"""
+openff-models
+Helper classes for Pydantic compatibility in the OpenFF stack
+"""
+from openff.models._version import get_versions
+
+__version__ = get_versions()["version"]

--- a/openff/models/exceptions.py
+++ b/openff/models/exceptions.py
@@ -3,10 +3,12 @@ class MissingUnitError(ValueError):
     Exception for data missing a unit tag.
     """
 
+
 class UnitValidationError(ValueError):
     """
     Exception for bad behavior when validating unit-tagged data.
     """
+
 
 class UnsupportedExportError(BaseException):
     """

--- a/openff/models/tests/test_types.py
+++ b/openff/models/tests/test_types.py
@@ -8,8 +8,8 @@ from openmm import unit as openmm_unit
 from pydantic import ValidationError
 
 from openff.models.exceptions import UnitValidationError
-from openff.models.types import ArrayQuantity, FloatQuantity
 from openff.models.models import DefaultModel
+from openff.models.types import ArrayQuantity, FloatQuantity
 
 
 class TestQuantityTypes:

--- a/openff/models/types.py
+++ b/openff/models/types.py
@@ -1,11 +1,9 @@
 """Custom models for dealing with unit-bearing quantities in a Pydantic-compatible manner."""
-import collections
 import json
 from typing import TYPE_CHECKING, Any, Dict
 
 import numpy as np
 from openff.units import unit
-from openff.utilities.utilities import has_package, requires_package
 from openmm import unit as openmm_unit
 
 from openff.models.exceptions import (
@@ -91,7 +89,6 @@ def _from_omm_quantity(val: openmm_unit.Quantity):
             "Found a openmm.unit.Unit wrapped around something other than a float-like "
             f"or np.ndarray-like. Found a unit wrapped around type {type(val_)}."
         )
-
 
 
 class QuantityEncoder(json.JSONEncoder):


### PR DESCRIPTION
Fixes #11 

```shell
git checkout init-version && python -m pip install -e . && python -c "from openff.models import __version__; print(__version__)"                                 10:14:27  ☁  97f7327 ☀
Previous HEAD position was 97f7327 Merge pull request #10 from mattwthompson/dependabot/github_actions/actions/checkout-3
Switched to branch 'init-version'
Obtaining file:///Users/mattthompson/software/openff-models
  Preparing metadata (setup.py) ... done
Installing collected packages: openff-models
  Attempting uninstall: openff-models
    Found existing installation: openff-models 0.0.0
    Uninstalling openff-models-0.0.0:
      Successfully uninstalled openff-models-0.0.0
  Running setup.py develop for openff-models
Successfully installed openff-models-0.0.0+2.ga0d00b1
0.0.0+2.ga0d00b1