### PR TITLE
Include `py.typed` in packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,4 +106,4 @@ ENV/
 *profraw
 
 # macOS
-.DS_store/
+.DS_store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   - id: black
     files: ^openff
 - repo: https://github.com/PyCQA/isort
-  rev: 5.11.0
+  rev: 5.11.4
   hooks:
   - id: isort
     files: ^openff

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include LICENSE
 include MANIFEST.in
 include CODE_OF_CONDUCT.md
 include versioneer.py
+include openff/models/py.typed
 
 graft openff-models
 global-exclude *.py[cod] __pycache__ *.so

--- a/devtools/conda-envs/no_openmm.yaml
+++ b/devtools/conda-envs/no_openmm.yaml
@@ -1,4 +1,4 @@
-name: openff-models-test
+name: openff-models-no-openmm
 channels:
   - conda-forge
 dependencies:

--- a/openff/models/models.py
+++ b/openff/models/models.py
@@ -1,3 +1,5 @@
+from typing import Any, Callable, Dict
+
 from openff.units import unit
 from pydantic import BaseModel
 
@@ -10,9 +12,9 @@ class DefaultModel(BaseModel):
     class Config:
         """Custom Pydantic configuration."""
 
-        json_encoders = {
+        json_encoders: Dict[Any, Callable] = {
             unit.Quantity: custom_quantity_encoder,
         }
-        json_loads = json_loader
-        validate_assignment = True
-        arbitrary_types_allowed = True
+        json_loads: Callable = json_loader
+        validate_assignment: bool = True
+        arbitrary_types_allowed: bool = True


### PR DESCRIPTION
## Description
I thought that `py.typed` would be included in the packaged tarballs, but it's not. It seems like `include_package_data=True` misses files that are not part of modules and/or not included in `MANIFEST.in`. Since the conda recipe calls `pip install .` internally I expect this change to have the same effect there.

This conflicts somewhat with current best practices (https://github.com/pypa/sampleproject/pull/155) but removing that file from our projects is a larger lift than I want to try for today.

```console
$ git checkout 0.0.3 && git clean -fdx && pip install . && ls $CONDA_PREFIX/lib/python3.11/site-packages/openff/models
HEAD is now at 56c30d2 Merge pull request #16 from openforcefield/openmm-optional
Removing .DS_Store
Removing __pycache__/
Removing build/
Removing openff_models.egg-info/
Processing /Users/mattthompson/software/openff-models
  Preparing metadata (setup.py) ... done
Building wheels for collected packages: openff-models
  Building wheel for openff-models (setup.py) ... done
  Created wheel for openff-models: filename=openff_models-0.0.3-py3-none-any.whl size=9630 sha256=da28c154668b00611a87cbf567120ad25253164928c17ca90cf09439c6ac3854
  Stored in directory: /Users/mattthompson/Library/Caches/pip/wheels/e0/b2/81/d7a551a5e4272049ee4de6e7956a2a05feed0ebf2752f2f91b
Successfully built openff-models
Installing collected packages: openff-models
Successfully installed openff-models-0.0.3
__init__.py   __pycache__   _version.py   exceptions.py models.py     tests         types.py
$ pip uninstall openff-models
Found existing installation: openff-models 0.0.3
Uninstalling openff-models-0.0.3:
  Would remove:
    /Users/mattthompson/mambaforge/envs/openff-models-no-openmm/lib/python3.11/site-packages/openff/models/*
    /Users/mattthompson/mambaforge/envs/openff-models-no-openmm/lib/python3.11/site-packages/openff_models-0.0.3.dist-info/*
Proceed (Y/n)? y
  Successfully uninstalled openff-models-0.0.3
$ git checkout include-py-typed && git clean -fdx && pip install . && ls $CONDA_PREFIX/lib/python3.11/site-packages/openff/models
Previous HEAD position was 56c30d2 Merge pull request #16 from openforcefield/openmm-optional
Switched to branch 'include-py-typed'
Removing __pycache__/
Removing build/
Removing openff_models.egg-info/
Processing /Users/mattthompson/software/openff-models
  Preparing metadata (setup.py) ... done
Building wheels for collected packages: openff-models
  Building wheel for openff-models (setup.py) ... done
  Created wheel for openff-models: filename=openff_models-0.0.3+1.g399b627-py3-none-any.whl size=9938 sha256=d717d4e9bcd864aec84ae4f7b739dd3156a7f0190933e4a37937850b025b3032
  Stored in directory: /Users/mattthompson/Library/Caches/pip/wheels/e0/b2/81/d7a551a5e4272049ee4de6e7956a2a05feed0ebf2752f2f91b
Successfully built openff-models
Installing collected packages: openff-models
Successfully installed openff-models-0.0.3+1.g399b627
__init__.py   __pycache__   _version.py   exceptions.py models.py     py.typed      tests         types.py