### PR TITLE
Floats really really floats

### DIFF
--- a/openff/models/tests/test_types.py
+++ b/openff/models/tests/test_types.py
@@ -61,7 +61,7 @@ class TestQuantityTypes:
         assert a.qux == 0.4 * unit.nanometer
         assert a.quix == 2.0 * unit.nanometer
         assert isinstance(a.quix.m, float)
-        assert a.quux == 1.0
+        assert a.quux == 1
         assert a.fnord == 4.2
         assert a.fum == "fum"
         assert a.zot == ["zot", 1, 4.2]

--- a/openff/models/tests/test_types.py
+++ b/openff/models/tests/test_types.py
@@ -22,8 +22,10 @@ class TestQuantityTypes:
             foo: FloatQuantity
             fuu: FloatQuantity
             bar: FloatQuantity["degree"]
+            barint: FloatQuantity["degree"]
             baz: FloatQuantity["nanometer"]
             qux: FloatQuantity["nanometer"]
+            quix: FloatQuantity["nanometer"]
             quux: int
             fnord: float
             fum: str
@@ -36,8 +38,10 @@ class TestQuantityTypes:
             foo=2.0 * unit.nanometer,
             fuu=2.0 * openmm.unit.nanometer,
             bar="90.0 degree",
+            barint="90 degree",
             baz=0.4 * openmm.unit.nanometer,
             qux=openmm.unit.Quantity(np.float64(0.4), openmm.unit.nanometer),
+            quix=openmm.unit.Quantity(2, openmm.unit.nanometer),
             quux=1,
             fnord=4.2,
             fum="fum",
@@ -45,14 +49,19 @@ class TestQuantityTypes:
             fred={"baz": 2},
         )
 
-        assert a.mass == 4 * unit.atomic_mass_constant
-        assert a.charge == 0 * unit.elementary_charge
+        assert a.mass == 4.0 * unit.atomic_mass_constant
+        assert a.charge == 0.0 * unit.elementary_charge
+        assert isinstance(a.charge.m, float)
         assert a.foo == 2.0 * unit.nanometer
         assert a.fuu == 2.0 * unit.nanometer
         assert a.bar == 90 * unit.degree
+        assert a.barint == 90.0 * unit.degree
+        assert isinstance(a.barint.m, float)
         assert a.baz == 0.4 * unit.nanometer
         assert a.qux == 0.4 * unit.nanometer
-        assert a.quux == 1
+        assert a.quix == 2.0 * unit.nanometer
+        assert isinstance(a.quix.m, float)
+        assert a.quux == 1.0
         assert a.fnord == 4.2
         assert a.fum == "fum"
         assert a.zot == ["zot", 1, 4.2]
@@ -60,13 +69,15 @@ class TestQuantityTypes:
 
         # TODO: Update with custom deserialization to == a.dict()
         assert json.loads(a.json()) == {
-            "mass": '{"val": 4, "unit": "atomic_mass_constant"}',
-            "charge": '{"val": 0, "unit": "elementary_charge"}',
+            "mass": '{"val": 4.0, "unit": "atomic_mass_constant"}',
+            "charge": '{"val": 0.0, "unit": "elementary_charge"}',
             "foo": '{"val": 2.0, "unit": "nanometer"}',
             "fuu": '{"val": 2.0, "unit": "nanometer"}',
             "bar": '{"val": 90.0, "unit": "degree"}',
+            "barint": '{"val": 90.0, "unit": "degree"}',
             "baz": '{"val": 0.4, "unit": "nanometer"}',
             "qux": '{"val": 0.4, "unit": "nanometer"}',
+            "quix": '{"val": 2.0, "unit": "nanometer"}',
             "quux": 1,
             "fnord": 4.2,
             "fum": "fum",

--- a/openff/models/types.py
+++ b/openff/models/types.py
@@ -56,7 +56,7 @@ else:
                     # some custom behavior could go here
                     assert unit_.dimensionality == val.dimensionality
                     # return through converting to some intended default units (taken from the class)
-                    val = float(val.m) * val.u
+                    val._magnitude = float(val.m)
                     return val.to(unit_)
                     # could return here, without converting
                     # (could be inconsistent with data model - heteregenous but compatible units)

--- a/openff/models/types.py
+++ b/openff/models/types.py
@@ -71,7 +71,8 @@ else:
                 if isinstance(val, str):
                     # could do custom deserialization here?
                     val = unit.Quantity(val).to(unit_)
-                    return float(val.m) * val.u
+                    val._magnitude = float(val._magnitude)
+                    return val
                 raise UnitValidationError(
                     f"Could not validate data of type {type(val)}"
                 )

--- a/openff/models/types.py
+++ b/openff/models/types.py
@@ -56,17 +56,22 @@ else:
                     # some custom behavior could go here
                     assert unit_.dimensionality == val.dimensionality
                     # return through converting to some intended default units (taken from the class)
+                    val = float(val.m) * val.u
                     return val.to(unit_)
                     # could return here, without converting
                     # (could be inconsistent with data model - heteregenous but compatible units)
                     # return val
                 if _is_openmm_quantity(val):
                     return _from_omm_quantity(val).to(unit_)
-                if isinstance(val, (float, int)) and not isinstance(val, bool):
+                if isinstance(val, int) and not isinstance(val, bool):
+                    # coerce ints into floats for a FloatQuantity
+                    return float(val) * unit_
+                if isinstance(val, float):
                     return val * unit_
                 if isinstance(val, str):
                     # could do custom deserialization here?
-                    return unit.Quantity(val).to(unit_)
+                    val = unit.Quantity(val).to(unit_)
+                    return float(val.m) * val.u
                 raise UnitValidationError(
                     f"Could not validate data of type {type(val)}"
                 )
@@ -91,7 +96,7 @@ def _from_omm_quantity(val: "openmm.unit.Quantity") -> unit.Quantity:
     val_ = val.value_in_unit(unit_)
     if type(val_) in {float, int}:
         unit_ = val.unit
-        return val_ * unit.Unit(str(unit_))
+        return float(val_) * unit.Unit(str(unit_))
     # Here is where the toolkit's ValidatedList could go, if present in the environment
     elif type(val_) in {tuple, list, np.ndarray}:
         array = np.asarray(val_)


### PR DESCRIPTION
## Description

This is somewhat motivated on an annoying bug we had where (e.g.) a `FloatQuantity` value of `1.0 * unit.nanometer` was creating a different json to a value of `1 * unit.nanometer`.  So instead FloatQuantity should always cast to float.


## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go
