### PR TITLE
Use Pydantic v1 API from v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.9", "3.11"]
         pydantic-version: ["1", "2"]
         openmm: [true, false]
         run-mypy: [false]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,14 +14,16 @@ defaults:
 
 jobs:
   test:
-    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}, OpenMM ${{ matrix.openmm }}
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}, OpenMM ${{ matrix.openmm }}, Pydantic ${{ matrix.pydantic-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10"]
+        pydantic-version: ["1", "2"]
         openmm: [true, false]
+        run-mypy: [false]
         exclude:
           - python-version: "3.10"
             os: macOS-latest
@@ -44,6 +46,7 @@ jobs:
         environment-file: devtools/conda-envs/test_env.yaml
         create-args: >-
           python=${{ matrix.python-version }}
+          pydantic=${{ matrix.pydantic-version }}
 
     - name: Install conda environment without OpenMM
       if: ${{ matrix.openmm == false }}
@@ -63,6 +66,7 @@ jobs:
         conda list
 
     - name: Run mypy
+      if: ${{ matrix.run-mypy == true }}
       run: |
         mypy -p "openff.models"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
   - id: trailing-whitespace
   - id: debug-statements
 - repo: https://github.com/psf/black
-  rev: 23.3.0
+  rev: 23.7.0
   hooks:
   - id: black
     files: ^openff
@@ -19,7 +19,7 @@ repos:
   - id: isort
     files: ^openff
 - repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
+  rev: 6.1.0
   hooks:
   - id: flake8
     files: ^openff
@@ -30,7 +30,7 @@ repos:
         'flake8-no-pep420',
     ]
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.4.0
+  rev: v3.10.1
   hooks:
   - id: pyupgrade
     files: ^openff

--- a/devtools/conda-envs/no_openmm.yaml
+++ b/devtools/conda-envs/no_openmm.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python
   - pip
-  - pydantic <2.0.0a0
+  - pydantic
   - openff-units
   - openff-utilities
   - pytest

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python
   - pip
-  - pydantic <2.0.0a0
+  - pydantic
   - openff-units
   - openff-utilities
   - pytest

--- a/openff/models/models.py
+++ b/openff/models/models.py
@@ -1,7 +1,12 @@
 from typing import Any, Callable, Dict
 
 from openff.units import unit
-from pydantic import BaseModel
+
+try:
+    from pydantic.v1 import BaseModel
+except ImportError:
+    from pydantic import BaseModel
+
 
 from openff.models.types import custom_quantity_encoder, json_loader
 

--- a/openff/models/tests/test_types.py
+++ b/openff/models/tests/test_types.py
@@ -190,9 +190,9 @@ class TestQuantityTypes:
         )
 
         # Ensure unyt scalars (unyt.unyt_quantity) are stored as floats
-        assert type(subject.age.m) == float
-        assert type(subject.height.m) == float
-        assert type(subject.doses.m) == np.ndarray
+        assert subject.age.m is float
+        assert subject.height.m is float
+        assert subject.doses.m is np.ndarray
 
     @skip_if_missing("unyt")
     @skip_if_missing("openmm.unit")

--- a/openff/models/tests/test_types.py
+++ b/openff/models/tests/test_types.py
@@ -4,11 +4,15 @@ import numpy as np
 import pytest
 from openff.units import unit
 from openff.utilities.testing import skip_if_missing
-from pydantic import ValidationError
 
 from openff.models.exceptions import UnitValidationError
 from openff.models.models import DefaultModel
 from openff.models.types import ArrayQuantity, FloatQuantity
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 
 class TestQuantityTypes:


### PR DESCRIPTION
## Description
This is an easier attempt at #26, enabling v2 to be installed while basically keeping the code the same, using `pydantic.v1`.

Thanks for @jthorton for tipping us off to https://docs.pydantic.dev/latest/migration/#continue-using-pydantic-v1-features.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Set up testing for both Pydantic versions
  - [x] Update codebase to use v1 from `pydantic.v1` import path

## Questions
- [ ] Question1

## Status
- [ ] Ready to go
