### PR TITLE
Fix parsing `list[openmm.unit.Quantity]` and parse `openmm.Vec3`

### DIFF
--- a/openff/models/tests/test_types.py
+++ b/openff/models/tests/test_types.py
@@ -2,7 +2,7 @@ import json
 
 import numpy as np
 import pytest
-from openff.units import unit
+from openff.units import Quantity, unit
 from openff.utilities.testing import skip_if_missing
 
 from openff.models.exceptions import UnitValidationError
@@ -306,6 +306,7 @@ def test_from_omm_quantity():
     with pytest.raises(UnitValidationError):
         _from_omm_quantity(True * openmm.unit.femtosecond)
 
+
 @skip_if_missing("openmm.unit")
 def test_from_omm_box_vectors():
     """Reproduce issue #35."""
@@ -322,7 +323,10 @@ def test_from_omm_box_vectors():
 
     validated = ArrayQuantity.validate_type(box_vectors)
 
+    assert isinstance(validated, Quantity)
+
     assert validated.shape == (3, 3)
+    assert validated.m.shape == (3, 3)
     assert validated.units == unit.nanometer
 
     for index, value in enumerate([4, 2, 5]):

--- a/openff/models/tests/test_types.py
+++ b/openff/models/tests/test_types.py
@@ -305,3 +305,25 @@ def test_from_omm_quantity():
 
     with pytest.raises(UnitValidationError):
         _from_omm_quantity(True * openmm.unit.femtosecond)
+
+@skip_if_missing("openmm.unit")
+def test_from_omm_box_vectors():
+    """Reproduce issue #35."""
+    import openmm
+    import openmm.unit
+
+    # mimic the output of getDefaultPeriodicBoxVectors, which returns
+    # list[openmm.unit.Quantity[openmm.unit.Vec3]]
+    box_vectors = [
+        openmm.unit.Quantity(openmm.Vec3(x=4, y=0, z=0), openmm.unit.nanometer),
+        openmm.unit.Quantity(openmm.Vec3(x=0, y=2, z=0), openmm.unit.nanometer),
+        openmm.unit.Quantity(openmm.Vec3(x=0, y=0, z=5), openmm.unit.nanometer),
+    ]
+
+    validated = ArrayQuantity.validate_type(box_vectors)
+
+    assert validated.shape == (3, 3)
+    assert validated.units == unit.nanometer
+
+    for index, value in enumerate([4, 2, 5]):
+        assert validated.m[index][index] == value


### PR DESCRIPTION
## Description
Resolves #35 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Explicitly deal with the special case of `list[openmm.unit.Quantity]`
  - [x] Attempt to convert `openmm.Vec3` to `numpy.ndarray`


## Status
- [ ] Ready to go
